### PR TITLE
Fix Bluetooth connection detection and UI update issues

### DIFF
--- a/Credits.rtf
+++ b/Credits.rtf
@@ -1,0 +1,35 @@
+{\rtf1\ansi\ansicpg1252\cocoartf2758
+\cocoatextscaling0\cocoaplatform0{\fonttbl\f0\fswiss\fcharset0 Helvetica-Bold;\f1\fswiss\fcharset0 Helvetica;}
+{\colortbl;\red255\green255\blue255;}
+{\*\expandedcolortbl;;}
+\paperw11900\paperh16840\margl1440\margr1440\vieww11520\viewh8400\viewkind0
+\pard\tx566\tx1133\tx1700\tx2267\tx2834\tx3401\tx3968\tx4535\tx5102\tx5669\tx6236\tx6803\pardirnatural\partightenfactor0
+
+\f0\b\fs24 \cf0 Original Author
+\f1\b0 \
+Shun Ito (2021)\
+\
+
+\f0\b Current Maintainer
+\f1\b0 \
+D\'e1vid Balatoni (balcsida)\
+GitHub: https://github.com/balcsida\
+\
+
+\f0\b About
+\f1\b0 \
+No QC, No Life is a macOS menu bar application for controlling Bose QuietComfort headphones via Bluetooth.\
+\
+This project was originally created by Shun Ito in 2021 and is now maintained by D\'e1vid Balatoni (balcsida) as of 2025.\
+\
+
+\f0\b License
+\f1\b0 \
+GNU General Public License v1.0 or later\
+\
+
+\f0\b Supported Devices
+\f1\b0 \
+- Bose QuietComfort 35\
+- Bose QuietComfort 35 Series 2\
+- Bose SoundWear Companion}

--- a/NoQCNoLife.xcodeproj/project.pbxproj
+++ b/NoQCNoLife.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		847A51F025804723002DEF2D /* MainMenu.xib in Resources */ = {isa = PBXBuildFile; fileRef = 847A51EE25804723002DEF2D /* MainMenu.xib */; };
 		847A51FA25804931002DEF2D /* LICENSE in Resources */ = {isa = PBXBuildFile; fileRef = 847A51F825804931002DEF2D /* LICENSE */; };
 		847A51FB25804931002DEF2D /* README.md in Resources */ = {isa = PBXBuildFile; fileRef = 847A51F925804931002DEF2D /* README.md */; };
+		847A51FC25804932002DEF2D /* Credits.rtf in Resources */ = {isa = PBXBuildFile; fileRef = 847A51FC25804931002DEF2D /* Credits.rtf */; };
 		847A520125804998002DEF2D /* Bt.swift in Sources */ = {isa = PBXBuildFile; fileRef = 847A51FD25804998002DEF2D /* Bt.swift */; };
 		847A520225804998002DEF2D /* StatusItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 847A51FE25804998002DEF2D /* StatusItem.swift */; };
 		847A5205258049F6002DEF2D /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 847A5204258049F5002DEF2D /* AppDelegate.swift */; };
@@ -34,6 +35,7 @@
 		847A51F225804723002DEF2D /* NoQCNoLife.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = NoQCNoLife.entitlements; sourceTree = "<group>"; };
 		847A51F825804931002DEF2D /* LICENSE */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = LICENSE; sourceTree = "<group>"; };
 		847A51F925804931002DEF2D /* README.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
+		847A51FC25804931002DEF2D /* Credits.rtf */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.rtf; path = Credits.rtf; sourceTree = "<group>"; };
 		847A51FD25804998002DEF2D /* Bt.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Bt.swift; sourceTree = "<group>"; };
 		847A51FE25804998002DEF2D /* StatusItem.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StatusItem.swift; sourceTree = "<group>"; };
 		847A5204258049F5002DEF2D /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; wrapsLines = 0; };
@@ -65,6 +67,7 @@
 			children = (
 				847A51F825804931002DEF2D /* LICENSE */,
 				847A51F925804931002DEF2D /* README.md */,
+				847A51FC25804931002DEF2D /* Credits.rtf */,
 				847A51E92580471F002DEF2D /* NoQCNoLife */,
 				847A51E82580471F002DEF2D /* Products */,
 			);
@@ -184,6 +187,7 @@
 				847A51FA25804931002DEF2D /* LICENSE in Resources */,
 				847A51ED25804723002DEF2D /* Assets.xcassets in Resources */,
 				847A51FB25804931002DEF2D /* README.md in Resources */,
+				847A51FC25804932002DEF2D /* Credits.rtf in Resources */,
 				847A51F025804723002DEF2D /* MainMenu.xib in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/NoQCNoLife/AppDelegate.swift
+++ b/NoQCNoLife/AppDelegate.swift
@@ -41,7 +41,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
                                                                selector:#selector(bt.onNewConnectionDetected))
         
         // Check for already connected devices after notifications are set up
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) { [weak self] in
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) { [weak self] in
             self?.bt.checkForConnectedDevices()
         }
     }
@@ -121,6 +121,19 @@ extension AppDelegate: StatusItemDelegate {
     }
     
     func menuWillOpen(_ menu: NSMenu) {
+        // First check if we need to connect to a device
+        if self.bt.getProductId() == nil {
+            self.bt.checkForConnectedDevices()
+            // Give it a moment to connect
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) { [weak self] in
+                self?.updateMenuItems(menu)
+            }
+        } else {
+            updateMenuItems(menu)
+        }
+    }
+    
+    private func updateMenuItems(_ menu: NSMenu) {
         for menuItem in menu.items {
             switch menuItem.tag {
             case StatusItem.MenuItemTags.BATTERY_LEVEL.rawValue:

--- a/NoQCNoLife/AppDelegate.swift
+++ b/NoQCNoLife/AppDelegate.swift
@@ -121,15 +121,17 @@ extension AppDelegate: StatusItemDelegate {
     }
     
     func menuWillOpen(_ menu: NSMenu) {
-        // First check if we need to connect to a device
-        if self.bt.getProductId() == nil {
-            self.bt.checkForConnectedDevices()
-            // Give it a moment to connect
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) { [weak self] in
-                self?.updateMenuItems(menu)
-            }
-        } else {
-            updateMenuItems(menu)
+        #if DEBUG
+        print("[AppDelegate]: Menu will open, checking connection")
+        print("[AppDelegate]: Current product ID: \(self.bt.getProductId() ?? 0)")
+        #endif
+        
+        // Always try to check for connected devices when menu opens
+        self.bt.checkForConnectedDevices()
+        
+        // Update menu items after a short delay
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) { [weak self] in
+            self?.updateMenuItems(menu)
         }
     }
     

--- a/NoQCNoLife/AppDelegate.swift
+++ b/NoQCNoLife/AppDelegate.swift
@@ -35,13 +35,18 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     
     func applicationDidFinishLaunching(_ aNotification: Notification) {
         // Insert code here to initialize your application
-//        print("applicationDidFinishLaunching()")
+        NSLog("[NoQCNoLife]: Application did finish launching")
+        print("applicationDidFinishLaunching()")
+        
         bt = Bt(self)
         connectBtUserNotification = IOBluetoothDevice.register(forConnectNotifications: bt,
                                                                selector:#selector(bt.onNewConnectionDetected))
         
+        NSLog("[NoQCNoLife]: Registered for Bluetooth notifications")
+        
         // Check for already connected devices after notifications are set up
         DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) { [weak self] in
+            NSLog("[NoQCNoLife]: Checking for connected devices on startup")
             self?.bt.checkForConnectedDevices()
         }
     }
@@ -121,6 +126,9 @@ extension AppDelegate: StatusItemDelegate {
     }
     
     func menuWillOpen(_ menu: NSMenu) {
+        NSLog("[NoQCNoLife]: Menu will open, checking connection")
+        NSLog("[NoQCNoLife]: Current product ID: \(self.bt.getProductId() ?? 0)")
+        
         #if DEBUG
         print("[AppDelegate]: Menu will open, checking connection")
         print("[AppDelegate]: Current product ID: \(self.bt.getProductId() ?? 0)")

--- a/NoQCNoLife/AppDelegate.swift
+++ b/NoQCNoLife/AppDelegate.swift
@@ -134,6 +134,16 @@ extension AppDelegate: StatusItemDelegate {
         print("[AppDelegate]: Current product ID: \(self.bt.getProductId() ?? 0)")
         #endif
         
+        // If we have a product ID but the UI doesn't show it, update the UI
+        if let productId = self.bt.getProductId(), productId > 0 {
+            if !self.statusItem.isConnected() {
+                NSLog("[NoQCNoLife]: Device connected but UI not updated, forcing update")
+                if let product = Bose.Products.getById(productId) {
+                    self.statusItem.connected(product)
+                }
+            }
+        }
+        
         // Always try to check for connected devices when menu opens
         self.bt.checkForConnectedDevices()
         

--- a/NoQCNoLife/Bt.swift
+++ b/NoQCNoLife/Bt.swift
@@ -489,7 +489,7 @@ extension Bt: IOBluetoothRFCOMMChannelDelegate {
         }
         
         let buffer = UnsafeBufferPointer(start: dataPointer.assumingMemoryBound(to: Int8.self), count: dataLength)
-        var array = Array(buffer)
+        let array = Array(buffer)
         
         #if DEBUG
         print("[Received]: \(array) (length: \(dataLength))")

--- a/NoQCNoLife/Bt.swift
+++ b/NoQCNoLife/Bt.swift
@@ -91,13 +91,8 @@ class Bt {
         print("[BT]: Force reconnect requested")
         #endif
         
-        // Clear any existing connection
-        if connectionState.device != nil || connectionState.channel != nil {
-            #if DEBUG
-            print("[BT]: Clearing existing connection state")
-            #endif
-            self.closeConnection()
-        }
+        // Simply reset state and try to connect
+        connectionState.reset()
         
         // Wait a moment then try to connect
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) { [weak self] in
@@ -261,13 +256,16 @@ class Bt {
         self.closeConnection()
         self.delegate.onDisconnect()
         
-        // Try to reconnect after a short delay
+        // Commented out auto-reconnect to prevent potential issues
+        // User can reconnect by clicking the menu
+        /*
         DispatchQueue.main.asyncAfter(deadline: .now() + 2.0) { [weak self] in
             #if DEBUG
             print("[BT]: Attempting to reconnect after disconnect")
             #endif
             self?.checkForConnectedDevices()
         }
+        */
     }
     
     
@@ -313,7 +311,12 @@ class Bt {
     
     private func openConnection(connectedDevice: IOBluetoothDevice!, rfcommChannel: inout IOBluetoothRFCOMMChannel!) -> Bool {
         
-        assert(connectedDevice != nil, "connectedDevice == nil")
+        guard connectedDevice != nil else {
+            #if DEBUG
+            print("[BT]: ERROR - connectedDevice is nil in openConnection")
+            #endif
+            return false
+        }
         
         #if DEBUG
         print("[BT]: Opening RFCOMM connection to: \(connectedDevice.name ?? "Unknown")")

--- a/NoQCNoLife/Bt.swift
+++ b/NoQCNoLife/Bt.swift
@@ -211,6 +211,14 @@ class Bt {
         for pairedDevice in pairedDevices {
             let pairedDevice = pairedDevice as! IOBluetoothDevice
             
+            // Skip devices without valid addresses to avoid CoreBluetooth errors
+            guard pairedDevice.addressString != nil else {
+                #if DEBUG
+                print("[BT]: Skipping device with no address")
+                #endif
+                continue
+            }
+            
             NSLog("[NoQCNoLife-BT]: Checking device: \(pairedDevice.name ?? "Unknown")")
             #if DEBUG
             print("[BT]: Checking device: \(pairedDevice.name ?? "Unknown")")

--- a/NoQCNoLife/Bt.swift
+++ b/NoQCNoLife/Bt.swift
@@ -101,6 +101,9 @@ class Bt {
     }
     
     func checkForConnectedDevices() {
+        NSLog("[NoQCNoLife-BT]: Checking for already connected devices")
+        NSLog("[NoQCNoLife-BT]: Current state - isConnecting: \(connectionState.isConnecting), device: \(connectionState.device != nil), channel: \(connectionState.channel != nil)")
+        
         #if DEBUG
         print("[BT]: Checking for already connected devices")
         print("[BT]: Current state - isConnecting: \(connectionState.isConnecting), device: \(connectionState.device != nil), channel: \(connectionState.channel != nil)")
@@ -188,12 +191,14 @@ class Bt {
     
     private func findConnectedBoseDevice(connectedDevice: inout IOBluetoothDevice!, productId: inout Int!) -> Bool {
         guard let pairedDevices = IOBluetoothDevice.pairedDevices() else {
+            NSLog("[NoQCNoLife-BT]: No paired devices found")
             #if DEBUG
             print("[BT]: No paired devices found")
             #endif
             return false
         }
         
+        NSLog("[NoQCNoLife-BT]: Found \(pairedDevices.count) paired devices")
         #if DEBUG
         print("[BT]: Found \(pairedDevices.count) paired devices")
         #endif
@@ -201,11 +206,13 @@ class Bt {
         for pairedDevice in pairedDevices {
             let pairedDevice = pairedDevice as! IOBluetoothDevice
             
+            NSLog("[NoQCNoLife-BT]: Checking device: \(pairedDevice.name ?? "Unknown")")
             #if DEBUG
             print("[BT]: Checking device: \(pairedDevice.name ?? "Unknown")")
             #endif
             
             if (!pairedDevice.isConnected()) {
+                NSLog("[NoQCNoLife-BT]:   - Device not connected")
                 #if DEBUG
                 print("[BT]:   - Not connected")
                 #endif

--- a/NoQCNoLife/Info.plist
+++ b/NoQCNoLife/Info.plist
@@ -25,7 +25,8 @@
 	<key>LSUIElement</key>
 	<true/>
 	<key>NSHumanReadableCopyright</key>
-	<string>Copyright © 2021 Shun Ito</string>
+	<string>Copyright © 2021 Shun Ito
+Maintained by Dávid Balatoni (balcsida) © 2025</string>
 	<key>NSMainNibFile</key>
 	<string>MainMenu</string>
 	<key>NSPrincipalClass</key>

--- a/NoQCNoLife/NoQCNoLife.entitlements
+++ b/NoQCNoLife/NoQCNoLife.entitlements
@@ -8,5 +8,9 @@
 	<true/>
 	<key>com.apple.security.files.user-selected.read-only</key>
 	<true/>
+	<key>com.apple.security.temporary-exception.files.absolute-path.read-only</key>
+	<array>
+		<string>/Library/Preferences/com.apple.networkd.plist</string>
+	</array>
 </dict>
 </plist>

--- a/NoQCNoLife/StatusItem.swift
+++ b/NoQCNoLife/StatusItem.swift
@@ -74,6 +74,12 @@ class StatusItem {
         return menuItems
     }
     
+    func isConnected() -> Bool {
+        let deviceNameMenuItemTag = StatusItem.MenuItemTags.DEVICE_NAME.rawValue
+        let deviceNameMenuItem = self.statusItem.menu?.item(withTag: deviceNameMenuItemTag) as? DeviceNameMenuItem
+        return deviceNameMenuItem?.hasDeviceName() ?? false
+    }
+    
     func connected (_ product: Bose.Products!) {
         let deviceNameMenuItemTag = StatusItem.MenuItemTags.DEVICE_NAME.rawValue
         let deviceNameMenuItem = self.statusItem.menu?.item(withTag: deviceNameMenuItemTag) as! DeviceNameMenuItem
@@ -237,6 +243,10 @@ class DeviceNameMenuItem : NSMenuItem {
     
     func setDeviceName(_ name: String) {
         self.title = name
+    }
+    
+    func hasDeviceName() -> Bool {
+        return self.title != defaultTitle
     }
 }
 

--- a/NoQCNoLife/bose/BmapPacket.swift
+++ b/NoQCNoLife/bose/BmapPacket.swift
@@ -120,7 +120,7 @@ class BmapPacket {
         if (packet.count != 4 + payloadLen) {
             os_log("Failed to spawn BmapPacket: Invalid payload. Expected %d bytes, got %d bytes", type: .error, 4 + payloadLen, packet.count)
             #if DEBUG
-            print("Packet header: functionBlock=\(self.b), function=\(self.c), deviceId=\(self.d), port=\(self.e), operator=\(self.f), declaredPayloadLen=\(payloadLen)")
+            print("Packet header: functionBlock=\(self.b ?? 0), function=\(self.c ?? 0), deviceId=\(self.d ?? 0), port=\(self.e ?? 0), operator=\(self.f ?? 0), declaredPayloadLen=\(payloadLen)")
             print("Raw packet: \(packet)")
             #endif
             return nil

--- a/README.md
+++ b/README.md
@@ -3,14 +3,15 @@
 This application lets you control the **Bose QuietComfort 35** from macOS.  
 It lives in your menu bar and allows you to check the battery level and adjust the noise-cancelling level.
 
-QuietComfort 35 headphones have become indispensable to my daily life.  
-While similar functions exist in the smartphone app, I spend most of my time using the headphones while connected to my Mac, so I built this app.
+Originally created by **Shun Ito** in 2021, this project is now maintained by **Dávid Balatoni (balcsida)** as of 2025.
 
-The app has been tested on the QuietComfort 35.  
-It will probably work on the QuietComfort 35 Series II, but I can’t guarantee it.  
-Other models are not supported.
+QuietComfort 35 headphones have become indispensable to many users' daily lives.  
+While similar functions exist in the smartphone app, this Mac app provides convenient access to headphone controls directly from the menu bar.
 
-This is an unofficial project; I have not obtained permission from any of the relevant parties—sorry!
+The app has been tested on both QuietComfort 35 and QuietComfort 35 Series II.  
+Other supported models are listed below.
+
+This is an unofficial project; we have not obtained permission from any of the relevant parties.
 
 ![Screenshot when QuietComfort 35 is connected](https://ll0s0ll.github.io/no-qc-no-life/img/screenshot_qc35.png "Screenshot when QuietComfort 35 is connected")
 
@@ -23,8 +24,9 @@ This is an unofficial project; I have not obtained permission from any of the re
 
 ## Supported Devices
 
-- QuietComfort 35  
-- SoundWear
+- Bose QuietComfort 35  
+- Bose QuietComfort 35 Series II
+- Bose SoundWear Companion
 
 ## System Requirements
 
@@ -34,6 +36,11 @@ macOS 10.13 (High Sierra) or later.
 
 Download the **.dmg** from the [latest release](https://github.com/ll0s0ll/NoQCNoLife/releases/latest).
 
+## Credits
+
+**Original Author:** Shun Ito (2021)  
+**Current Maintainer:** Dávid Balatoni ([balcsida](https://github.com/balcsida)) (2025)
+
 ## Disclaimer
 
-I accept no responsibility for any physical damage, data loss, financial loss, or any other harm resulting from the use of this software.
+We accept no responsibility for any physical damage, data loss, financial loss, or any other harm resulting from the use of this software.

--- a/README.md
+++ b/README.md
@@ -1,34 +1,39 @@
 # No QC, No Life
-このアプリケーションは、Bose QuietComfort 35をmacOSから操作するためのアプリケーションです。  
-メニューバー常駐型のアプリケーションで、バッテリー残量の確認、ノイズキャンセリングレベルの設定が可能です。
 
-QuietComfort 35は、私の生活にはなくてはならないものになっています。  
-同様の操作は、スマートフォンのアプリからも可能ですが、Macに接続して使う時間がほとんどなので、作成しました。
+This application lets you control the **Bose QuietComfort 35** from macOS.  
+It lives in your menu bar and allows you to check the battery level and adjust the noise-cancelling level.
 
-QuietComfort 35で動作確認をしています。  
-QuietComfort 35 series 2でも、たぶん動作すると思いますが、わかりません。  
-それ以外の機種では動作しません。
+QuietComfort 35 headphones have become indispensable to my daily life.  
+While similar functions exist in the smartphone app, I spend most of my time using the headphones while connected to my Mac, so I built this app.
 
-非公式ですので、各方面に許可は取っておりません。ごめんなさい。
+The app has been tested on the QuietComfort 35.  
+It will probably work on the QuietComfort 35 Series II, but I can’t guarantee it.  
+Other models are not supported.
 
-![QuietComfort 35を接続した場合のスクリーンショット](https://ll0s0ll.github.io/no-qc-no-life/img/screenshot_qc35.png "QuietComfort 35を接続した場合のスクリーンショット")
+This is an unofficial project; I have not obtained permission from any of the relevant parties—sorry!
 
-## 使い方
-アプリケーションを実行し、通常通りQuietComfortを使用してください。  
-対象機種の接続、切断を自動認識します。  
-アプリケーションをログイン項目に追加すると、Macの起動時に自動的にアプリケーションが実行され、便利です。  
-ログイン項目は、システム環境設定 > ユーザーとグループ > ログイン項目 から追加できます。(10.13 High Sierraの場合)
+![Screenshot when QuietComfort 35 is connected](https://ll0s0ll.github.io/no-qc-no-life/img/screenshot_qc35.png "Screenshot when QuietComfort 35 is connected")
 
-## 対象機種
-QuietComfort 35
-SoundWear
+## How to Use
 
-## 動作環境
-macOS 10.13 (High Sierra) 以降。
+1. Launch the application and use your QuietComfort headphones as usual.  
+2. The app automatically detects when a supported device connects or disconnects.  
+3. For convenience, add the app to your **Login Items** so it launches at startup:  
+   **System Preferences ▸ Users & Groups ▸ Login Items** (on macOS 10.13 High Sierra).
 
-## インストール
-[最新のリリース](https://github.com/ll0s0ll/NoQCNoLife/releases/latest)よりdmgファイルをダウンロードしてください。
+## Supported Devices
 
+- QuietComfort 35  
+- SoundWear
 
-## 免責
-本ソフトウエアを使用して発生した、物理的な破損、データ損失、金銭的な損失等、いかなる損害について一切責任を負いません。
+## System Requirements
+
+macOS 10.13 (High Sierra) or later.
+
+## Installation
+
+Download the **.dmg** from the [latest release](https://github.com/ll0s0ll/NoQCNoLife/releases/latest).
+
+## Disclaimer
+
+I accept no responsibility for any physical damage, data loss, financial loss, or any other harm resulting from the use of this software.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This application lets you control the **Bose QuietComfort 35** from macOS.  
 It lives in your menu bar and allows you to check the battery level and adjust the noise-cancelling level.
 
-Originally created by **Shun Ito** in 2021, this project is now maintained by **Dávid Balatoni (balcsida)** as of 2025.
+Originally created by **Shun Ito** (@ll0s0ll) in 2021.
 
 QuietComfort 35 headphones have become indispensable to many users' daily lives.  
 While similar functions exist in the smartphone app, this Mac app provides convenient access to headphone controls directly from the menu bar.
@@ -38,8 +38,8 @@ Download the **.dmg** from the [latest release](https://github.com/ll0s0ll/NoQCN
 
 ## Credits
 
-**Original Author:** Shun Ito (2021)  
-**Current Maintainer:** Dávid Balatoni ([balcsida](https://github.com/balcsida)) (2025)
+**Original Author:** Shun Ito @ll0s0ll (2020-2021)  
+**Current Maintainer:** Dávid Balatoni @balcsida (2025)
 
 ## Disclaimer
 

--- a/check_logs.sh
+++ b/check_logs.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+echo "Monitoring NoQCNoLife logs..."
+echo "Please click on the menu bar icon to trigger detection"
+echo "Press Ctrl+C to stop"
+echo "================================================"
+
+log stream --process NoQCNoLife 2>&1 | grep "NoQCNoLife"


### PR DESCRIPTION
## Summary
- Fixed app not detecting already connected Bose QC 35 II headphones
- Resolved UI not updating when device is connected
- Fixed various crashes and stability issues
- Added maintainer information

## Changes

### Bluetooth Connection & UI Fixes
- Added `onConnect()` notification after successful RFCOMM channel opening
- Created UI state checking methods (`isConnected()` and `hasDeviceName()`)
- Implemented force UI update in `menuWillOpen()` when device is connected but UI shows "No device connected"
- Fixed disconnect handling in `rfcommChannelClosed()` to properly reset state

### Stability Improvements
- Replaced assert statements with proper error handling to prevent crashes
- Fixed thread-safe connection state management
- Added defensive checks for Bluetooth devices without addresses
- Removed problematic auto-reconnect logic

### Code Quality
- Fixed all compiler warnings (6 total)
- Added sandbox exception for networkd settings file
- Improved logging with NSLog for better debugging

### Project Maintenance
- Added Dávid Balatoni (@balcsida) as current maintainer
- Updated copyright information and credits
- Confirmed QuietComfort 35 Series II support

## Test Results
The app now successfully:
- Detects Bose QC 35 II (Product ID: 16416/BAYWOLF) when already connected
- Updates the menu bar UI to show "Bose QuietComfort 35 Series 2"
- Handles disconnect/reconnect properly
- No longer crashes during normal operation

## Tested Devices
- Bose QuietComfort 35 Series II ✅