### PR TITLE
Fix connection issues and improve user experience

### DIFF
--- a/NoQCNoLife/AppDelegate.swift
+++ b/NoQCNoLife/AppDelegate.swift
@@ -75,8 +75,29 @@ extension AppDelegate: BluetoothDelegate {
         #endif
         self.statusItem.connected(product)
         
+        // Don't automatically set ANR mode on connection - it interrupts the device
+        // and causes a "boop" sound. Users can manually set it if needed.
+        // The device will maintain its last setting anyway.
+        /*
         if let lastSelectedAnrMode = PreferenceManager.getLastSelectedAnrMode(product) {
             if (!self.bt.sendSetGetAnrModePacket(lastSelectedAnrMode)) {
+                self.noiseCancelModeChanged(nil)
+            }
+        }
+        */
+        
+        // Request battery level and noise cancellation mode after a short delay
+        // This gives the device time to stabilize after connection
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) { [weak self] in
+            guard let self = self else { return }
+            
+            // Get battery level
+            if (!self.bt.sendGetBatteryLevelPacket()) {
+                self.batteryLevelStatus(nil)
+            }
+            
+            // Get current noise cancellation mode (just to display, not to set)
+            if (!self.bt.sendGetAnrModePacket()) {
                 self.noiseCancelModeChanged(nil)
             }
         }

--- a/NoQCNoLife/StatusItem.swift
+++ b/NoQCNoLife/StatusItem.swift
@@ -107,20 +107,34 @@ class StatusItem {
     
     func setBassControlStep(_ step: Int?) {
         let tag = StatusItem.MenuItemTags.BASS_CONTROL.rawValue
-        let menuItem = self.statusItem.menu?.item(withTag: tag) as! BassControlMenuItem
+        guard let menuItem = self.statusItem.menu?.item(withTag: tag) as? BassControlMenuItem else {
+            #if DEBUG
+            print("[StatusItem]: Bass control menu item not found, skipping update")
+            #endif
+            return
+        }
         menuItem.setBassControlStep(step)
-        
     }
     
     func setBatteryLevel(_ level: Int?) {
         let tag = StatusItem.MenuItemTags.BATTERY_LEVEL.rawValue
-        let menuItem = self.statusItem.menu?.item(withTag: tag) as! BatteryLevelMenuItem
+        guard let menuItem = self.statusItem.menu?.item(withTag: tag) as? BatteryLevelMenuItem else {
+            #if DEBUG
+            print("[StatusItem]: Battery menu item not found, skipping update")
+            #endif
+            return
+        }
         menuItem.setBatteryLevel(level)
     }
     
     func setNoiseCancelMode(_ mode: Bose.AnrMode?) {
         let tag: Int = StatusItem.MenuItemTags.NOISE_CANCEL_MODE.rawValue
-        let menuItem = self.statusItem.menu?.item(withTag: tag) as! NoiseCancelModeMenuItem
+        guard let menuItem = self.statusItem.menu?.item(withTag: tag) as? NoiseCancelModeMenuItem else {
+            #if DEBUG
+            print("[StatusItem]: Noise cancel menu item not found, skipping update")
+            #endif
+            return
+        }
         menuItem.setNoiseCancelMode(mode)
     }
 }


### PR DESCRIPTION
## Summary
This PR fixes several issues that occur when connecting Bose QC35 II headphones, improving the overall user experience.

## Problems Fixed

### 1. 🔇 Removed automatic noise cancellation setting on connection
**Problem**: When connecting, the app would automatically set the last saved noise cancellation mode, which:
- Caused an audible "boop" sound
- Interrupted the device's voice announcement of the device name
- Was unnecessary since the headphones maintain their last setting

**Solution**: Removed the automatic ANR mode setting on connection. Users can still manually change it if needed.

### 2. 🔋 Fixed battery status showing "N/A" 
**Problem**: When the device connects while the menu is open, the battery status would show "N/A" until the menu was closed and reopened.

**Solution**: Now automatically requests battery level and current ANR mode after a 1-second delay when the device connects, allowing the connection to stabilize first.

### 3. 🛡️ Added safety checks for menu updates
**Problem**: Potential crashes if trying to update menu items that don't exist yet.

**Solution**: Added guard checks before updating battery, noise cancellation, and bass control menu items.

## Testing
- Connected/disconnected Bose QC35 II multiple times
- Verified no "boop" sound on connection
- Confirmed device can complete its name announcement
- Battery status updates automatically after connection
- No crashes when updating menu items

## User Experience Improvements
✅ Smoother, quieter connection experience
✅ Device name announcement not interrupted
✅ Battery status available immediately
✅ More stable and crash-resistant