### PR TITLE
Fix GitHub Actions warnings and Homebrew tap authentication

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -119,13 +119,16 @@ jobs:
           HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN || secrets.GITHUB_TOKEN }}
         run: |
           # Try to update the Homebrew tap
-          # This requires a Personal Access Token with repo permissions
+          # This requires a Fine-grained Personal Access Token
           # Add it as HOMEBREW_TAP_TOKEN secret in repository settings
           
           if [ -z "${{ secrets.HOMEBREW_TAP_TOKEN }}" ]; then
             echo "::warning title=Homebrew Tap Update::HOMEBREW_TAP_TOKEN secret not set. Manual update required."
             echo "To enable automatic updates:"
-            echo "1. Create a Personal Access Token with 'repo' permissions"
+            echo "1. Create a Fine-grained Personal Access Token:"
+            echo "   - Go to GitHub Settings → Developer settings → Fine-grained tokens"
+            echo "   - Select only 'balcsida/homebrew-tap' repository"
+            echo "   - Grant 'Contents: Read and Write' permission"
             echo "2. Add it as HOMEBREW_TAP_TOKEN secret in repository settings"
             echo ""
             echo "Manual update command:"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,12 +76,11 @@ jobs:
           
       - name: Create Release
         id: create_release
-        uses: actions/create-release@v1
+        uses: softprops/action-gh-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tag_name: ${{ github.ref }}
-          release_name: Release ${{ github.ref_name }}
+          name: Release ${{ github.ref_name }}
           body: |
             ## NoQCNoLife ${{ github.ref_name }}
             
@@ -110,35 +109,32 @@ jobs:
             - macOS 10.13 (High Sierra) or later
             - Bluetooth enabled
             
-          draft: false
-          prerelease: false
-          
-      - name: Upload DMG
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./NoQCNoLife-${{ steps.get_version.outputs.VERSION }}.dmg
-          asset_name: NoQCNoLife-${{ steps.get_version.outputs.VERSION }}.dmg
-          asset_content_type: application/x-apple-diskimage
-          
-      - name: Upload Checksums
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./checksums.txt
-          asset_name: checksums.txt
-          asset_content_type: text/plain
+          files: |
+            NoQCNoLife-${{ steps.get_version.outputs.VERSION }}.dmg
+            checksums.txt
           
       - name: Update Homebrew Tap
+        continue-on-error: true
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN || secrets.GITHUB_TOKEN }}
         run: |
+          # Try to update the Homebrew tap
+          # This requires a Personal Access Token with repo permissions
+          # Add it as HOMEBREW_TAP_TOKEN secret in repository settings
+          
+          if [ -z "${{ secrets.HOMEBREW_TAP_TOKEN }}" ]; then
+            echo "::warning title=Homebrew Tap Update::HOMEBREW_TAP_TOKEN secret not set. Manual update required."
+            echo "To enable automatic updates:"
+            echo "1. Create a Personal Access Token with 'repo' permissions"
+            echo "2. Add it as HOMEBREW_TAP_TOKEN secret in repository settings"
+            echo ""
+            echo "Manual update command:"
+            echo "./scripts/update-homebrew-tap.sh ${{ steps.get_version.outputs.VERSION }} ${{ steps.checksums.outputs.SHA256 }}"
+            exit 0
+          fi
+          
           # Clone the tap repository using token
-          git clone https://${GITHUB_TOKEN}@github.com/balcsida/homebrew-tap.git tap-repo
+          git clone https://${HOMEBREW_TAP_TOKEN}@github.com/balcsida/homebrew-tap.git tap-repo
           cd tap-repo
           
           # Configure git
@@ -172,5 +168,5 @@ jobs:
           
           # Commit and push
           git add Casks/noqcnolife.rb
-          git commit -m "Update NoQCNoLife to v${{ steps.get_version.outputs.VERSION }}"
-          git push
+          git commit -m "Update NoQCNoLife to v${{ steps.get_version.outputs.VERSION }}" || echo "No changes to commit"
+          git push || echo "Push failed - manual update required"

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -54,9 +54,30 @@ This document describes how to create a new release of NoQCNoLife.
 
 ## Homebrew Formula
 
-The Homebrew tap is **automatically updated** by GitHub Actions when you create a release.
+The Homebrew tap can be **automatically updated** by GitHub Actions when you create a release.
 
 The tap repository is located at: `github.com/balcsida/homebrew-tap`
+
+### Enabling Automatic Updates
+
+To enable automatic Homebrew tap updates:
+
+1. **Create a Personal Access Token**:
+   - Go to GitHub Settings → Developer settings → Personal access tokens → Tokens (classic)
+   - Click "Generate new token (classic)"
+   - Give it a name like "Homebrew Tap Updater"
+   - Select the `repo` scope (full control of private repositories)
+   - Generate the token and copy it
+
+2. **Add the token as a repository secret**:
+   - Go to your NoQCNoLife repository settings
+   - Navigate to Secrets and variables → Actions
+   - Click "New repository secret"
+   - Name: `HOMEBREW_TAP_TOKEN`
+   - Value: Paste your Personal Access Token
+   - Click "Add secret"
+
+Once configured, the GitHub Action will automatically update the Homebrew tap after each release.
 
 Users can install NoQCNoLife via Homebrew:
 ```bash

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -62,12 +62,17 @@ The tap repository is located at: `github.com/balcsida/homebrew-tap`
 
 To enable automatic Homebrew tap updates:
 
-1. **Create a Personal Access Token**:
-   - Go to GitHub Settings → Developer settings → Personal access tokens → Tokens (classic)
-   - Click "Generate new token (classic)"
+1. **Create a Fine-grained Personal Access Token**:
+   - Go to GitHub Settings → Developer settings → Personal access tokens → Fine-grained tokens
+   - Click "Generate new token"
    - Give it a name like "Homebrew Tap Updater"
-   - Select the `repo` scope (full control of private repositories)
-   - Generate the token and copy it
+   - Set expiration (e.g., 90 days or custom)
+   - Under "Repository access", select "Selected repositories"
+   - Choose only `balcsida/homebrew-tap` repository
+   - Under "Permissions" → "Repository permissions", set:
+     - **Contents**: Read and Write (to update formula files)
+     - **Metadata**: Read (automatically selected)
+   - Click "Generate token" and copy it
 
 2. **Add the token as a repository secret**:
    - Go to your NoQCNoLife repository settings

--- a/docs/HOMEBREW_TAP_TOKEN.md
+++ b/docs/HOMEBREW_TAP_TOKEN.md
@@ -1,0 +1,99 @@
+# Setting up Homebrew Tap Auto-Update with Fine-grained Token
+
+This guide explains how to set up automatic Homebrew tap updates using GitHub's fine-grained personal access tokens, which are more secure than classic tokens.
+
+## Why Fine-grained Tokens?
+
+Fine-grained personal access tokens offer better security:
+- Limited to specific repositories (only `homebrew-tap` in our case)
+- Minimal required permissions (only Contents read/write)
+- Can set expiration dates
+- Better audit trail
+
+## Step-by-Step Setup
+
+### 1. Create the Fine-grained Token
+
+1. Go to [GitHub Settings → Developer settings → Personal access tokens → Fine-grained tokens](https://github.com/settings/personal-access-tokens/new)
+
+2. Configure the token:
+   - **Token name**: `NoQCNoLife Homebrew Tap Updater`
+   - **Expiration**: Choose based on your preference (90 days recommended)
+   - **Description**: `Allows NoQCNoLife releases to update homebrew-tap`
+
+3. Set **Repository access**:
+   - Select "Selected repositories"
+   - Click "Select repositories" 
+   - Choose only: `balcsida/homebrew-tap`
+
+4. Set **Repository permissions**:
+   - Expand "Repository permissions"
+   - Find **Contents** and set to: `Read and write`
+   - **Metadata** will be automatically set to `Read`
+   - All other permissions should remain as "No access"
+
+5. Review the summary:
+   ```
+   Selected repositories: 1
+   - balcsida/homebrew-tap
+   
+   Repository permissions:
+   - Contents: Read and write
+   - Metadata: Read
+   ```
+
+6. Click "Generate token" and **copy the token immediately** (you won't see it again)
+
+### 2. Add Token to NoQCNoLife Repository
+
+1. Go to your [NoQCNoLife repository settings](https://github.com/balcsida/NoQCNoLife/settings/secrets/actions)
+
+2. Click "New repository secret"
+
+3. Add the secret:
+   - **Name**: `HOMEBREW_TAP_TOKEN`
+   - **Secret**: Paste the token you copied
+   - Click "Add secret"
+
+### 3. Verify Setup
+
+The next time you create a release (push a version tag), the GitHub Action will:
+1. Build and release the DMG
+2. Automatically update the Homebrew tap using your token
+3. Users can immediately update via `brew upgrade --cask noqcnolife`
+
+## Token Expiration
+
+When your token expires:
+1. Create a new fine-grained token following the same steps
+2. Update the `HOMEBREW_TAP_TOKEN` secret with the new token
+3. Delete the expired token from your GitHub settings
+
+## Troubleshooting
+
+### Token not working?
+- Verify the token has access to `balcsida/homebrew-tap` repository
+- Check that Contents permission is set to "Read and write"
+- Ensure the secret name is exactly `HOMEBREW_TAP_TOKEN`
+
+### Workflow still failing?
+- Check the [Actions tab](https://github.com/balcsida/NoQCNoLife/actions) for detailed logs
+- The step is set to `continue-on-error`, so it won't break releases
+- You can always manually update using: `./scripts/update-homebrew-tap.sh`
+
+## Security Best Practices
+
+- Use fine-grained tokens instead of classic tokens
+- Set reasonable expiration dates (90 days recommended)
+- Only grant minimal required permissions
+- Rotate tokens regularly
+- Never commit tokens to code
+
+## Manual Alternative
+
+If you prefer not to use tokens, you can manually update after each release:
+```bash
+./scripts/update-homebrew-tap.sh <version> <sha256>
+```
+
+The release workflow will show the exact command with the correct values.


### PR DESCRIPTION
## Summary
This PR fixes the GitHub Actions deprecation warnings and resolves the Homebrew tap update authentication issue.

## Problems Fixed

### 1. 🔧 Deprecated `set-output` warnings
**Problem**: GitHub Actions was showing warnings about deprecated `set-output` commands from old action versions.

**Solution**: 
- Replaced `actions/create-release@v1` with `softprops/action-gh-release@v1`
- Simplified asset uploads using the new action's built-in file support
- This eliminates all deprecation warnings

### 2. 🔐 Homebrew tap update authentication failure
**Problem**: The workflow failed when trying to push to the homebrew-tap repository because GITHUB_TOKEN doesn't have cross-repository permissions.

**Solution**:
- Made the Homebrew tap update step continue on error (won't fail the whole workflow)
- Added support for `HOMEBREW_TAP_TOKEN` secret for automatic updates
- Shows clear instructions when the token is not configured
- Gracefully handles failures with helpful messages

## How to Enable Automatic Homebrew Updates

1. **Create a Personal Access Token**:
   - Go to GitHub Settings → Developer settings → Personal access tokens
   - Generate a token with `repo` scope
   
2. **Add as Repository Secret**:
   - Go to repository Settings → Secrets and variables → Actions
   - Add new secret named `HOMEBREW_TAP_TOKEN`
   - Paste your token

Once configured, future releases will automatically update the Homebrew tap.

## Changes
- Updated to modern GitHub Actions (softprops/action-gh-release@v1)
- Fixed authentication for cross-repository access
- Added comprehensive documentation in RELEASING.md
- Made workflow more resilient to failures

## Testing
- Workflow will no longer show deprecation warnings
- Homebrew tap update will either work (with token) or show helpful instructions (without token)
- Release creation will always succeed regardless of tap update status