### PR TITLE
Improve UI text: Use 'Noise cancellation' instead of 'Noise cancel'

### DIFF
--- a/NoQCNoLife/Info.plist
+++ b/NoQCNoLife/Info.plist
@@ -32,6 +32,6 @@ Maintained by Dávid Balatoni (balcsida) © 2025</string>
 	<key>NSPrincipalClass</key>
 	<string>NSApplication</string>
 	<key>NSBluetoothAlwaysUsageDescription</key>
-	<string>NoQCNoLife uses Bluetooth to connect with Bose QuietComfort 35 and SoundWear devices, enabling you to check battery levels and adjust noise cancelling settings directly from your Mac</string>
+	<string>NoQCNoLife uses Bluetooth to connect with Bose QuietComfort 35 and SoundWear devices, enabling you to check battery levels and adjust noise cancellation settings directly from your Mac</string>
 </dict>
 </plist>

--- a/NoQCNoLife/StatusItem.swift
+++ b/NoQCNoLife/StatusItem.swift
@@ -131,7 +131,7 @@ class StatusItem {
         let tag: Int = StatusItem.MenuItemTags.NOISE_CANCEL_MODE.rawValue
         guard let menuItem = self.statusItem.menu?.item(withTag: tag) as? NoiseCancelModeMenuItem else {
             #if DEBUG
-            print("[StatusItem]: Noise cancel menu item not found, skipping update")
+            print("[StatusItem]: Noise cancellation menu item not found, skipping update")
             #endif
             return
         }
@@ -273,7 +273,7 @@ class NoiseCancelModeMenuItem : NSMenuItem {
         
         self.delegate = delegate
         
-        super.init(title: "Noise cancel: N/A", action: nil, keyEquivalent: "")
+        super.init(title: "Noise cancellation: N/A", action: nil, keyEquivalent: "")
         
         self.tag = StatusItem.MenuItemTags.NOISE_CANCEL_MODE.rawValue
         self.target = self
@@ -330,12 +330,12 @@ class NoiseCancelModeMenuItem : NSMenuItem {
     
     func setNoiseCancelMode(_ mode: Bose.AnrMode!) {
         if (mode == nil) {
-            self.title = "Noise cancel: error"
+            self.title = "Noise cancellation: error"
             for subMenuItem in self.submenu?.items ?? [] {
                 subMenuItem.state = NSControl.StateValue.off
             }
         } else {
-            self.title = "Noise cancel: \(mode.toString())"
+            self.title = "Noise cancellation: \(mode.toString())"
             for subMenuItem in self.submenu?.items ?? [] {
                 if (subMenuItem.tag == mode.rawValue) {
                     subMenuItem.state = NSControl.StateValue.on

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ![Screenshot when QuietComfort 35 II is connected](https://github.com/user-attachments/assets/d0f9c1ae-5379-41c8-b9e3-d3423c211c2a "Screenshot when QuietComfort 35 II is connected")
 
 This application lets you control the **Bose QuietComfort 35** from macOS.  
-It lives in your menu bar and allows you to check the battery level and adjust the noise-cancelling level.
+It lives in your menu bar and allows you to check the battery level and adjust the noise cancellation level.
 
 Originally created by **Shun Ito** (@ll0s0ll) in 2021.
 


### PR DESCRIPTION
## Summary
This PR improves the UI text by replacing "Noise cancel" with "Noise cancellation" throughout the application for better grammar and professional appearance.

## Changes

### UI Text Updates
- **Menu items**: Changed from "Noise cancel: High/Low/Off" to "Noise cancellation: High/Low/Off"
- **Error states**: "Noise cancel: error" → "Noise cancellation: error"
- **Initial state**: "Noise cancel: N/A" → "Noise cancellation: N/A"

### Documentation Updates
- **Info.plist**: Updated Bluetooth permission description
- **README.md**: Updated feature description
- **Debug messages**: Updated for consistency

## Screenshots
Before: `Noise cancel: High`
After: `Noise cancellation: High`

## Why This Change?
- "Noise cancellation" is the grammatically correct noun form
- Provides a more professional and polished appearance
- Consistent with industry standard terminology

## Testing
- Menu displays correctly with new text
- All noise cancellation modes show proper labels
- No functional changes, only text improvements