### PR TITLE
Replace menu bar icons with SF Symbols

### DIFF
--- a/NoQCNoLife.xcodeproj/project.pbxproj
+++ b/NoQCNoLife.xcodeproj/project.pbxproj
@@ -25,6 +25,7 @@
 		847A521B25804B34002DEF2D /* StatusFunctionBlock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 847A521525804B34002DEF2D /* StatusFunctionBlock.swift */; };
 		847A521C25804B34002DEF2D /* ProductInfoFunctionBlock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 847A521625804B34002DEF2D /* ProductInfoFunctionBlock.swift */; };
 		84896F3D269BBE9D00B62D1A /* PreferenceManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84896F3C269BBE9D00B62D1A /* PreferenceManager.swift */; };
+		E811D27F2E4B7050002AC4F3 /* SFSafeSymbols in Frameworks */ = {isa = PBXBuildFile; productRef = E811D27E2E4B7050002AC4F3 /* SFSafeSymbols */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -56,6 +57,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				E811D27F2E4B7050002AC4F3 /* SFSafeSymbols in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -170,6 +172,9 @@
 				Base,
 			);
 			mainGroup = 847A51DE2580471F002DEF2D;
+			packageReferences = (
+				E811D27D2E4B7050002AC4F3 /* XCRemoteSwiftPackageReference "SFSafeSymbols" */,
+			);
 			productRefGroup = 847A51E82580471F002DEF2D /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
@@ -426,6 +431,25 @@
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
+
+/* Begin XCRemoteSwiftPackageReference section */
+		E811D27D2E4B7050002AC4F3 /* XCRemoteSwiftPackageReference "SFSafeSymbols" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/SFSafeSymbols/SFSafeSymbols";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 6.2.0;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		E811D27E2E4B7050002AC4F3 /* SFSafeSymbols */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = E811D27D2E4B7050002AC4F3 /* XCRemoteSwiftPackageReference "SFSafeSymbols" */;
+			productName = SFSafeSymbols;
+		};
+/* End XCSwiftPackageProductDependency section */
 	};
 	rootObject = 847A51DF2580471F002DEF2D /* Project object */;
 }

--- a/docs/SFSAFESYMBOLS_SETUP.md
+++ b/docs/SFSAFESYMBOLS_SETUP.md
@@ -1,0 +1,42 @@
+# Adding SFSafeSymbols to NoQCNoLife
+
+SFSafeSymbols provides compile-time safe SF Symbol references for the menu bar icons.
+
+## Setup Instructions
+
+1. Open `NoQCNoLife.xcodeproj` in Xcode
+
+2. Add Swift Package Dependency:
+   - Select the project in the navigator
+   - Select the NoQCNoLife project (not the target)
+   - Go to "Package Dependencies" tab
+   - Click the "+" button
+   - Enter the repository URL: `https://github.com/SFSafeSymbols/SFSafeSymbols.git`
+   - Set version rule to: "Up to Next Major Version" from `6.2.0`
+   - Click "Add Package"
+
+3. Add to Target:
+   - When prompted, ensure "SFSafeSymbols" is added to the "NoQCNoLife" target
+   - Click "Add Package"
+
+## Benefits
+
+- **Compile-time Safety**: Symbol names are checked at compile time
+- **Auto-completion**: Xcode provides auto-completion for all available symbols
+- **Type Safety**: No more string-based symbol names
+- **Cleaner Code**: More readable and maintainable
+
+## Usage
+
+The app now uses SFSafeSymbols for all menu bar icons:
+- Device disconnected: `waveformCircle`
+- NC High: `waveformCircleFill` 
+- NC Low: `waveformCircle`
+- NC Off: `waveform`
+- Wind Mode: `waveformPath`
+
+## Requirements
+
+- macOS 11.0+ (Big Sur or later)
+- Xcode 13.0+
+- Swift 5.5+


### PR DESCRIPTION
## Summary
- Replace custom SVG assets with native SF Symbols
- Add dynamic menu bar icon that reflects noise cancellation level
- Implement type-safe symbol references using SFSafeSymbols

## Changes
- Added SFSafeSymbols Swift package dependency (v6.2.0)
- Updated StatusItem.swift to use SF Symbols exclusively
- Removed custom ButtonImg SVG assets from Asset Catalog
- Updated deployment target to macOS 11.0 (required for SF Symbols)
- Added documentation for SFSafeSymbols setup

## Icon Behavior
The menu bar icon now dynamically changes based on noise cancellation mode:
- **Device disconnected**: `waveformCircle` (empty circle with waveform)
- **NC High**: `waveformCircleFill` (filled circle with waveform)
- **NC Low**: `waveformCircle` (empty circle with waveform)  
- **NC Off**: `waveform` (just waveform, no circle)
- **Wind Mode**: `waveformPath` (waveform with path indicator)

## Benefits
- Native macOS UI consistency with SF Symbols
- Type-safe symbol references (compile-time checking)
- Dynamic icon updates reflect device status
- Smaller app size (no custom SVG assets)
- Better support for different display densities

## Requirements
- macOS 11.0+ (Big Sur or later)
- Xcode 13.0+
- Swift 5.5+

## Testing
- Icons display correctly in menu bar
- Icon changes when noise cancellation mode changes
- All symbols are validated at compile time
- App builds and runs without warnings