### PR TITLE
Fix connection status display and noise cancellation detection

### DIFF
--- a/NoQCNoLife/Bt.swift
+++ b/NoQCNoLife/Bt.swift
@@ -327,6 +327,11 @@ class Bt {
         
         self.disconnectBtUserNotification = device.register(forDisconnectNotification: self,
                                                            selector: #selector(Bt.onDisconnectDetected))
+        
+        // IMPORTANT: Notify the delegate that we're connected
+        // This was missing when connection happens through onNewConnectionDetected
+        NSLog("[NoQCNoLife-BT]: Connection established through onNewConnectionDetected, notifying delegate")
+        self.delegate.onConnect()
     }
     
     private func openConnection(connectedDevice: IOBluetoothDevice!, rfcommChannel: inout IOBluetoothRFCOMMChannel!) -> Bool {


### PR DESCRIPTION
## Summary
- Fix battery and noise cancellation showing "N/A" when device is already connected at app launch
- Add automatic detection of noise cancellation changes made from headphone button
- Improve connection handling and status updates

## Issues Fixed
- Battery level and NC mode showed "N/A" when headphones were already connected at startup
- Menu bar icon didn't update to reflect NC mode until menu was clicked
- NC changes made using headphone button weren't detected
- Missing `onConnect()` call when device connected through `onNewConnectionDetected`

## Changes

### Bt.swift
- Added missing `delegate.onConnect()` call in `onNewConnectionDetected` method
- This ensures UI updates and status requests happen for already connected devices

### AppDelegate.swift
- Added periodic timer (5 seconds) to poll for NC mode changes
- Increased delay for initial status requests to 1.5 seconds for stability
- Added comprehensive logging for debugging connection issues
- Proper timer cleanup on disconnect and app termination
- Added timer property to track periodic updates

## Testing
- App correctly shows battery and NC status when launched with connected headphones
- Menu bar icon updates immediately to reflect current NC mode
- NC changes from headphone button are detected within 5 seconds
- No excessive battery drain from periodic polling (only NC mode, not battery)
- Proper cleanup when device disconnects

## Technical Details
- Periodic polling only requests NC mode, not battery level (to save power)
- 5-second interval provides good balance between responsiveness and efficiency
- Enhanced logging helps diagnose connection issues in debug builds
- Timer is properly invalidated on disconnect to prevent memory leaks